### PR TITLE
XML entities aren't escaped

### DIFF
--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -323,15 +323,24 @@ module.exports = (function() {
             level--;
           }
 
+          var xmlEncode = function(text) {
+            return String(text)
+              .replace(/&/g, '&amp;')
+              .replace(/\"/g, '&quot;')
+              .replace(/\'/g, '&apos;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')
+          }
+
           var toAttributes = function(obj) {
             var string = "";
-            for (key in obj) { string += " " + key + "=" + "\"" + obj[key] + "\"" }
+            for (key in obj) { string += " " + key + "=" + "\"" + xmlEncode(obj[key]) + "\"" }
             return string;
           }
 
           var commonElement = function(verb) {
             return function(str, attributes) {
-              append("<" + verb + toAttributes(attributes) + ">" + str + "</" + verb + ">");
+              append("<" + verb + toAttributes(attributes) + ">" + xmlEncode(str) + "</" + verb + ">");
             }
           }
 


### PR DESCRIPTION
``` javascript
require('twilio-js').TwiML.build(function(r) {
    r.gather(function(){}, {
        action: 'http://example.com/query?test=123&test2=456'
    });
})
```

This code produce incorrect XML because ampersand isn't escaped properly. So Twilio fails to parse it.

I included a quick fix for it, but the best solution probably will be to use a xml library.
