### PR TITLE
handle JSON.parse errors properly

### DIFF
--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -34,7 +34,11 @@ module.exports = (function() {
         // Return if no callback function given. User doesn't care about response.
         if(!fn) return;
         // If a 2xx response, pass in response to callback
-        body = JSON.parse(body);
+        try {
+          body = JSON.parse(body);
+        } catch(err) {
+          return fn(err);
+        }
         if(!e && Math.floor(r.statusCode / 100) == 2) {
           fn(null, new klass(body));
         } else {


### PR DESCRIPTION
JSON.parse can throw if an argument isn't json, and there's no way to catch this error outside of the library.
